### PR TITLE
page_entries_info compatibility

### DIFF
--- a/lib/sunspot_with_kaminari.rb
+++ b/lib/sunspot_with_kaminari.rb
@@ -36,6 +36,19 @@ module Sunspot
       def any?
         total > 0
       end
+	  
+      def offset_value
+        @query.per_page * (@query.page - 1)
+      end
+
+      def total_count
+        total
+      end
+	  
+	  def length
+		hits.size
+	  end
+	  
     end
   end
 end


### PR DESCRIPTION
Added 3 methods to enable helpers like page_entries_info, as mentioned here
https://github.com/amatsuda/kaminari/issues/56

(First time I've done this, sorry if I mess it up)
