### PR TITLE
Add Kaminari 0.14.1 compatibility(September 11, 2012) 

### DIFF
--- a/lib/sunspot_with_kaminari.rb
+++ b/lib/sunspot_with_kaminari.rb
@@ -13,7 +13,7 @@ module SunspotWithKaminari
       #
       # Integer:: Total number of pages for matching documents
       #
-      def num_pages
+      def total_pages
         (total.to_f / @query.per_page).ceil
       end
 

--- a/lib/sunspot_with_kaminari/version.rb
+++ b/lib/sunspot_with_kaminari/version.rb
@@ -1,3 +1,3 @@
 module SunspotWithKaminari
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/sunspot_with_kaminari.gemspec
+++ b/sunspot_with_kaminari.gemspec
@@ -13,9 +13,9 @@ Gem::Specification.new do |s|
   s.description = %q{Extends sunspot to be compatible with kaminari for pagination}
 
   s.rubyforge_project = "sunspot_with_kaminari"
-  
+
   s.add_dependency 'sunspot_rails'
-  s.add_dependency 'kaminari'
+  s.add_dependency 'kaminari', '>= 0.14.0'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Recent versions of Kaminari use a method called "total_pages" instead of "num_pages".
This pull request fixes that issue.
