### PR TITLE
Default per_page to Kaminari's default setting.

### DIFF
--- a/lib/sunspot_with_kaminari.rb
+++ b/lib/sunspot_with_kaminari.rb
@@ -22,7 +22,7 @@ module SunspotWithKaminari
       # Integer:: Number of records displayed per page
       #
       def limit_value
-        @query.per_page
+        @query.per_page || Kaminari.config.default_per_page
       end
 
       def empty?


### PR DESCRIPTION
Default pagination's limit value to Kaminari's default config (either specified by Kaminari or Kaminari's config block in your project's initializer).
