### PR TITLE
Add page method to search

### DIFF
--- a/lib/sunspot_with_kaminari.rb
+++ b/lib/sunspot_with_kaminari.rb
@@ -1,3 +1,5 @@
+require 'sunspot'
+
 module SunspotWithKaminari
   module Search
     module AbstractSearchInstanceMethods
@@ -31,6 +33,11 @@ module SunspotWithKaminari
 
       def any?
         total > 0
+      end
+
+      def page(current_page)
+        query.paginate(current_page, nil)
+        self.execute.results
       end
     end
   end

--- a/sunspot_with_kaminari.gemspec
+++ b/sunspot_with_kaminari.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "sunspot_with_kaminari"
 
+  s.add_dependency 'sunspot'
   s.add_dependency 'sunspot_rails'
   s.add_dependency 'kaminari', '>= 0.14.0'
 


### PR DESCRIPTION
- allows search.page(i) if a search has not already been
  executed

``` ruby
Sunspot.config.pagination.default_per_page = 50

search = Model.search.build do
  keywords "blah"
end

search.page(2)
```
